### PR TITLE
missing dependencies in readme on debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tabliato est un logiciel pour GNU/Linux permettant d'écrire des tablatures d'ac
 ## Compilation
 
 ```
-sudo apt-get install qtbase5-dev lilypond timidity timidity-interfaces-extra freepats
+sudo apt-get install qtbase5-dev lilypond timidity timidity-interfaces-extra freepats libpoppler-qt5-dev qtmultimedia5-dev
 qmake
 make
 ```


### PR DESCRIPTION
Hello, 

I managed to compile tabliato on my debian testing machine, but the readme was missing 2 deps. ( to bad the website mention a pre-packaged .deb but the link point to this repo... ). 

Awesome piece of software, thank you very much for this ! 